### PR TITLE
Fix save setting.

### DIFF
--- a/PowerMode/PowerModeOptionsPackage.cs
+++ b/PowerMode/PowerModeOptionsPackage.cs
@@ -110,16 +110,17 @@ namespace PowerMode
         public override void SaveSettingsToStorage()
         {
             base.SaveSettingsToStorage();
-            AlphaRemoveAmount = ExplosionParticle.AlphaRemoveAmount;
-            Color = ExplosionParticle.Color;
-            FrameDelay = ExplosionParticle.FrameDelay;
-            Gravity = ExplosionParticle.Gravity;
-            MaxParticleCount = ExplosionParticle.MaxParticleCount;
-            MaxSideVelocity = ExplosionParticle.MaxSideVelocity;
-            MaxUpVelocity = ExplosionParticle.MaxUpVelocity;
-            StartAlpha = ExplosionParticle.StartAlpha;
-            ShakeEnabled = ExplosionViewportAdornment.ShakeEnabled;
-            ParticlesEnabled = ExplosionViewportAdornment.ParticlesEnabled;
+
+            ExplosionParticle.AlphaRemoveAmount = AlphaRemoveAmount;
+            ExplosionParticle.Color = Color;
+            ExplosionParticle.FrameDelay = FrameDelay;
+            ExplosionParticle.Gravity = Gravity;
+            ExplosionParticle.MaxParticleCount = MaxParticleCount;
+            ExplosionParticle.MaxSideVelocity = MaxSideVelocity;
+            ExplosionParticle.MaxUpVelocity = MaxUpVelocity;
+            ExplosionParticle.StartAlpha = StartAlpha;
+            ExplosionViewportAdornment.ShakeEnabled = ShakeEnabled;
+            ExplosionViewportAdornment.ParticlesEnabled = ParticlesEnabled;
         }
     }
 


### PR DESCRIPTION
Members of OptionPageGrid have new values stored when SaveSettingsToStorage is called.
We should update ExplosionParticle here.

This also makes setting color in option page works.

However, it doesn't store/load correctly when restarting Visual Studio...
