### PR TITLE
Added option to get color from environment

### DIFF
--- a/PowerMode/ExplosionParticle.cs
+++ b/PowerMode/ExplosionParticle.cs
@@ -53,6 +53,8 @@ namespace PowerMode
 
         public static double AlphaRemoveAmount { get; set; } = 0.045;
 
+        public static bool bGetColorFromEnvironment { get; set; } = false;
+
         public static Color Color { get; set; } = Colors.Black;
 
         public static int FrameDelay { get; set; } = 17;
@@ -99,6 +101,11 @@ namespace PowerMode
             var upVelocity = Random.NextDouble() * MaxUpVelocity;
             var leftVelocity = Random.NextDouble() * MaxSideVelocity * Random.NextSignSwap();
             var brush = new SolidColorBrush(Color);
+            if (bGetColorFromEnvironment)
+            {
+                var svc = Microsoft.VisualStudio.Shell.Package.GetGlobalService(typeof(Microsoft.VisualStudio.Shell.Interop.SVsUIShell)) as Microsoft.VisualStudio.Shell.Interop.IVsUIShell5;
+                brush = new SolidColorBrush(Microsoft.VisualStudio.Shell.VsColors.GetThemedWPFColor(svc, Microsoft.VisualStudio.PlatformUI.EnvironmentColors.PanelTextColorKey));
+            }
             brush.Freeze();
             var drawing = new GeometryDrawing(brush, null, geometry);
             drawing.Freeze();

--- a/PowerMode/PowerModeOptionsPackage.cs
+++ b/PowerMode/PowerModeOptionsPackage.cs
@@ -48,8 +48,13 @@ namespace PowerMode
         public double AlphaRemoveAmount { get; set; } = 0.045;
 
         [Category("Power Mode")]
+        [DisplayName("Explosion Particle - get color from environment")]
+        [Description("Whether to get the color from the environment theme or not - overrides Explosion Particle Color value if set")]
+        public bool bGetColorFromEnvironment { get; set; } = false;
+
+        [Category("Power Mode")]
         [DisplayName("Explosion Particle Color")]
-        [Description("The color of the explosion particle")]
+        [Description("The color of the explosion particle - ignored if 'get color from environment' is set")]
         public Color Color { get; set; } = Colors.Black;
 
         [Category("Power Mode")]
@@ -96,6 +101,7 @@ namespace PowerMode
         {
             base.LoadSettingsFromStorage();
             ExplosionParticle.AlphaRemoveAmount = AlphaRemoveAmount;
+            ExplosionParticle.bGetColorFromEnvironment = bGetColorFromEnvironment;
             ExplosionParticle.Color = Color;
             ExplosionParticle.FrameDelay = FrameDelay;
             ExplosionParticle.Gravity = Gravity;
@@ -112,6 +118,7 @@ namespace PowerMode
             base.SaveSettingsToStorage();
 
             ExplosionParticle.AlphaRemoveAmount = AlphaRemoveAmount;
+            ExplosionParticle.bGetColorFromEnvironment = bGetColorFromEnvironment;
             ExplosionParticle.Color = Color;
             ExplosionParticle.FrameDelay = FrameDelay;
             ExplosionParticle.Gravity = Gravity;


### PR DESCRIPTION
This will automatically set the explosion particle to the color of the text so that a dark theme produces a light particle and a light theme produces a dark particle (which makes the particle visible against the background). Disabled by default since it overrides the manual color setting. It might be a good idea for this to default 'true' since it will allow the addon to look correct in all environments without customizing settings, but I'll leave that up to the original author to decide.
