### PR TITLE
Add Combo Mode

### DIFF
--- a/PowerMode/OptionPageGeneral.cs
+++ b/PowerMode/OptionPageGeneral.cs
@@ -149,6 +149,15 @@ namespace PowerMode
             get { return ExplosionParticle.StartAlpha; }
             set { ExplosionParticle.StartAlpha = value; }
         }
+
+        [Category("Power Mode")]
+        [DisplayName("Combo Threshold")]
+        [Description("The number of keypresses required to turn on Power Mode. Set to 0 to always enable Power Mode.")]
+        public int ComboThreshold
+        {
+            get { return ExplosionViewportAdornment.ComboActivationThreshold; }
+            set { ExplosionViewportAdornment.ComboActivationThreshold = value; }
+        }
     }
 
 }


### PR DESCRIPTION
Makes it so the mode is not enabled before a certain number of key presses (by default, 200)
Turns off after the user has been idle for 10 seconds.
This is disabled by setting the threshold to 0, but could potentially be made into a separate flag to disable/enable.
