### PR TITLE
Performance improvments

### DIFF
--- a/PowerMode/ExplosionParticle.cs
+++ b/PowerMode/ExplosionParticle.cs
@@ -94,7 +94,7 @@ namespace PowerMode
             geometry = new EllipseGeometry(_rect);
         }
 
-        public async System.Threading.Tasks.Task Explode()
+        public async void Explode()
         {
             if (ParticleCount > MaxParticleCount)
                 return;


### PR DESCRIPTION
- Undo was really slow, so I made sure we only apply the effects when we are actually typing (aka. TextEditAction)
  The EditTag is null when we are backspacing, copying and pasting, and we still want to apply the effects for those.
- Move shaking to the very end, in case we get more changes in one go. Prevents several shakes from taking place at once.
  This appear to fix Issue #11 and #12
