### PR TITLE
source.extension.vsixmanifest

### DIFF
--- a/PowerModeV2/source.extension.vsixmanifest
+++ b/PowerModeV2/source.extension.vsixmanifest
@@ -1,25 +1,24 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-  <Metadata>
-    <Identity Id="PowerMode.Liam Morrow.53e86655-8a9a-4544-ac12-4aef42035b5f" Version="2.0" Language="en-US" Publisher="Liam Morrow" />
-    <DisplayName>PowerMode</DisplayName>
-    <Description xml:space="preserve">An extension that attempts to clone the power mode in Atom found here : https://atom.io/packages/activate-power-mode</Description>
-    <License>LICENCE.txt</License>
-    <Icon>Resources\PowerModePackage.ico</Icon>
-    <PreviewImage>demo.gif</PreviewImage>
-  </Metadata>
-  <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[11.0,15.0]" />
-  </Installation>
-  <Dependencies>
-    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-    <Dependency Id="Microsoft.VisualStudio.MPF.15.0" DisplayName="Visual Studio MPF 15.0" d:Source="Installed" Version="[15.0]" />
-  </Dependencies>
-  <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[11.0,16.0)" DisplayName="Visual Studio core editor" />
-  </Prerequisites>
-  <Assets>
-    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
-  </Assets>
+    <Metadata>
+        <Identity Id="PowerMode.Liam Morrow.53e86655-8a9a-4544-ac12-4aef42035b5f" Version="2.0" Language="en-US" Publisher="Liam Morrow" />
+        <DisplayName>PowerMode</DisplayName>
+        <Description xml:space="preserve">An extension that attempts to clone the power mode in Atom found here : https://atom.io/packages/activate-power-mode</Description>
+        <License>LICENCE.txt</License>
+        <Icon>Resources\PowerModePackage.ico</Icon>
+        <PreviewImage>demo.gif</PreviewImage>
+    </Metadata>
+    <Installation>
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[11.0,16.0]" />
+    </Installation>
+    <Dependencies>
+        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+    </Dependencies>
+    <Prerequisites>
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[11.0,)" DisplayName="Visual Studio core editor" />
+    </Prerequisites>
+    <Assets>
+        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+        <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
+    </Assets>
 </PackageManifest>


### PR DESCRIPTION
updated for 2019. just the manifest needed updating. the rest works like usually.

the mpf entry can be removed safeley, see here: https://devblogs.microsoft.com/visualstudio/how-to-upgrade-extensions-to-support-visual-studio-2019/